### PR TITLE
Added customizable marker stroke to markers of type "x"

### DIFF
--- a/core/include/actsvg/core/draw.hpp
+++ b/core/include/actsvg/core/draw.hpp
@@ -999,9 +999,9 @@ static inline svg::object marker(const std::string &id_, const point2 &at_,
         scalar a_y = at_[1];
         scalar h_s = 0.5 * size;
         marker_group.add_object(
-            line(id_ + "_ml0", {a_x - h_s, a_y - h_s}, {a_x + h_s, a_y + h_s}));
+            line(id_ + "_ml0", {a_x - h_s, a_y - h_s}, {a_x + h_s, a_y + h_s}, marker_._stroke));
         marker_group.add_object(
-            line(id_ + "_ml1", {a_x - h_s, a_y + h_s}, {a_x + h_s, a_y - h_s}));
+            line(id_ + "_ml1", {a_x - h_s, a_y + h_s}, {a_x + h_s, a_y - h_s}, marker_._stroke));
     }
 
     // Plot the arrow if not empty


### PR DESCRIPTION
Fixed a bug where markers of type "x" would always use the default stroke.

**Before** (custom marker stroke style not applied)
<img src="https://github.com/fredevb/actsvg/assets/92879080/5691365e-b154-46f4-8cba-53a09b97df62" width="250" height="250">

**After**  (custom marker stroke style applied)
<img src="https://github.com/fredevb/actsvg/assets/92879080/726afd10-1cbc-40c4-8446-c2ff91453006" width="250" height="250">